### PR TITLE
Restructured the CFU definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,7 @@ edition = "2021"
 [dependencies]
 embedded-io-async = "0.6.1"
 
-binary_serde = "1.0.24"
 defmt = { version = "0.3", optional = true }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
-heapless = "0.8.0"
 log = { version = "0.4.14", optional = true }
 
 [features]

--- a/src/components.rs
+++ b/src/components.rs
@@ -10,10 +10,8 @@ pub trait CfuComponentInfo {
     /// Not async as this should be an element of struct that implements this trait
     fn get_component_id(&self) -> ComponentId;
     /// Validate the CFU offer for the component
-    /// returns a CfuOfferResponseStatus with additional info on Reject Reason in the Err case.
-    fn is_offer_valid(
-        &self,
-    ) -> impl Future<Output = Result<CfuOfferResponseStatus, (CfuOfferResponseStatus, RejectReason)>>;
+    /// returns an OfferStatus with additional info on Reject Reason in the Err case.
+    fn is_offer_valid(&self) -> impl Future<Output = Result<OfferStatus, (OfferStatus, OfferRejectReason)>>;
     /// Returns whether or not this component is a primary component
     /// Not async as this should be an element of struct that implements this trait
     /// Default implementation returns false,


### PR DESCRIPTION
1) Removed the use of binary_serde::{binary_serde_bitfield, BinarySerde, BitfieldBitOrder, Endianness}; 
2) Renamed structures and variables for consistency with the protocol spec 
3) Structures are packed based on LSB to reduce overhead at the user implementations
4) Added tests

running 7 tests
test protocol_definitions::tests::test_fwupdate_content_command_serialization_deserialization ... ok
test protocol_definitions::tests::test_fwupdate_content_response_serialization_deserialization ... ok
test protocol_definitions::tests::test_fwupdate_offer_extended_serialization_deserialization ... ok
test protocol_definitions::tests::test_fwupdate_offer_information_serialization_deserialization ... ok
test protocol_definitions::tests::test_fwupdate_offer_serialization_deserialization ... ok
test protocol_definitions::tests::test_fwupdate_offer_response_serialization_deserialization ... ok
test protocol_definitions::tests::test_get_fw_version_response_serialization_deserialization ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests embedded_cfu_protocol

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s