### PR TITLE
Implement FwVersion type conversions to and from u32

### DIFF
--- a/src/protocol_definitions.rs
+++ b/src/protocol_definitions.rs
@@ -23,6 +23,23 @@ pub struct FwVersion {
     pub major: u8,
 }
 
+// Explicit conversions for FwVersion and u32
+impl FwVersion {
+    pub fn new(fw_version: u32) -> Self {
+        Self {
+            variant: (fw_version & 0xFF) as u8,
+            minor: ((fw_version >> 8) & 0xFFFF) as u16,
+            major: ((fw_version >> 24) & 0xFF) as u8,
+        }
+    }
+}
+
+impl From<FwVersion> for u32 {
+    fn from(ver: FwVersion) -> Self {
+        ((ver.major as u32) << 24) | ((ver.minor as u32) << 8) | ver.variant as u32
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// LSB first Representation of GetFwVersionResponse


### PR DESCRIPTION
Add FwVersion type implementations to create from a u32 and convert into a u32

Validated conversions back and forth:
```
INFO  Version u32: 0x1020304
INFO  Version object: FwVersion { variant: 4, minor: 515, major: 1 }       
INFO  Version object converted back to u32: 0x1020304
```