### PR TITLE
Adding sync version of CfuWriter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-cfu-protocol"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,6 @@
-use super::*;
+use core::future::Future;
+
+use crate::components::CfuComponentTraits;
 
 /// CfuReceiveContent trait defines behavior needed for a Cfu client (receiver) to process CFU commands
 /// E is an error type that can be defined by the implementor
@@ -7,37 +9,13 @@ use super::*;
 pub trait CfuReceiveContent<T, C, E: Default> {
     /// receives a CFU command from a Host and processes the contents
     /// Typestates here allow for flexible implementations
-    fn process_command(&self, args: Option<T>, cmd: C) -> impl Future<Output = Result<(), E>> {
-        default_process_command::<T, C, E>(args, cmd)
-    }
+    fn process_command(&self, args: Option<T>, cmd: C) -> impl Future<Output = Result<(), E>>;
+
     /// For all components, run their storage_prepare() method
     /// Typestates here allow for flexible implementations
     fn prepare_components(
         &self,
         args: Option<T>,
         primary_component: impl CfuComponentTraits,
-    ) -> impl Future<Output = Result<(), E>> {
-        default_prepare_components::<T, E>(args, primary_component)
-    }
-}
-
-/// Helper function to provide a default implementation for process_command
-async fn default_process_command<T, C, E: Default>(args: Option<T>, _cmd: C) -> Result<(), E> {
-    if args.is_some() {
-        trace!("unexpected args to default_process_command function");
-        trace!("potentially missing implementation of process_command in CfuReceiveContent trait")
-    }
-    Ok(())
-}
-
-/// Helper function to provide a default implementation for prepare_components
-async fn default_prepare_components<T, E: Default>(
-    args: Option<T>,
-    _primary_component: impl CfuComponentTraits,
-) -> Result<(), E> {
-    if args.is_some() {
-        trace!("unexpected args to default_prepare_components function");
-        trace!("potentially missing implementation of prepare_components in CfuReceiveContent trait")
-    }
-    Ok(())
+    ) -> impl Future<Output = Result<(), E>>;
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,32 +1,39 @@
 use core::future::Future;
 
-use crate::protocol_definitions::*;
-use crate::{CfuWriter, CfuWriterError};
+use crate::protocol_definitions::{
+    CfuProtocolError, ComponentId, FwVersion, OfferRejectReason, OfferStatus, MAX_SUBCMPT_COUNT,
+};
+use crate::writer::CfuWriterError;
 
 pub trait CfuComponentInfo {
     /// Gets the current fw version of the component
     fn get_fw_version(&self) -> impl Future<Output = Result<FwVersion, CfuProtocolError>>;
+
     /// Gets the component's id
     /// Not async as this should be an element of struct that implements this trait
     fn get_component_id(&self) -> ComponentId;
+
     /// Validate the CFU offer for the component
     /// returns an OfferStatus with additional info on Reject Reason in the Err case.
     fn is_offer_valid(&self) -> impl Future<Output = Result<OfferStatus, (OfferStatus, OfferRejectReason)>>;
+
     /// Returns whether or not this component is a primary component
     /// Not async as this should be an element of struct that implements this trait
     /// Default implementation returns false,
     fn is_primary_component(&self) -> bool {
         false
     }
+
     /// Returns whether or not this component has a dual-bank memory layout
     /// Not async as this should be an element of struct that implements this trait
     fn is_dual_bank(&self) -> bool;
+
     /// Returns sub-component ids if this component has any
     /// Not async as this should be an element of struct that implements this trait
     fn get_subcomponents(&self) -> [Option<ComponentId>; MAX_SUBCMPT_COUNT];
 }
 
-pub trait CfuComponentStorage: CfuWriter {
+pub trait CfuComponentStorage {
     fn storage_prepare(&self) -> impl Future<Output = Result<(), CfuWriterError>>;
     fn storage_write(&self) -> impl Future<Output = Result<(), CfuWriterError>>;
     fn storage_finalize(&self) -> impl Future<Output = Result<(), CfuWriterError>>;

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,9 +1,10 @@
-//! Logging macro implementations and other formating functions
+//! Logging macro implementations and other formatting functions
 
 #[cfg(all(feature = "log", feature = "defmt", not(doc)))]
 compile_error!("features `log` and `defmt` are mutually exclusive");
 
-#[cfg(all(not(doc), feature = "defmt"))]
+#[cfg(all(feature = "defmt", not(doc)))]
+#[doc(hidden)]
 mod defmt {
     /// Logs a trace message using the underlying logger
     #[macro_export]
@@ -61,7 +62,8 @@ mod defmt {
     }
 }
 
-#[cfg(all(not(doc), feature = "log"))]
+#[cfg(all(feature = "log", not(doc)))]
+#[doc(hidden)]
 mod log {
     /// Logs a trace message using the underlying logger
     #[macro_export]
@@ -120,7 +122,7 @@ mod log {
 }
 
 // Provide this implementation for `cargo doc`
-#[cfg(any(doc, not(any(feature = "defmt", feature = "log"))))]
+#[cfg(any(not(any(feature = "defmt", feature = "log")), doc))]
 mod none {
     /// Logs a trace message using the underlying logger
     #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ use core::future::Future;
 
 use embedded_io_async::{Read, ReadExactError, Seek, SeekFrom};
 
-use crate::components::*;
 use crate::protocol_definitions::*;
 
 pub mod client;
@@ -11,6 +10,7 @@ pub mod components;
 pub mod fmt;
 pub mod host;
 pub mod protocol_definitions;
+pub mod writer;
 
 // re-export the error enum
 pub use CfuProtocolError::*;
@@ -42,93 +42,4 @@ pub async fn read_from_exact<I: CfuImage>(
     image.read_exact(buf).await
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum CfuWriterError {
-    StorageError,
-    ByteConversionError,
-    Other,
-}
-
-/// This is a temporary change and will be revisited later
-pub trait CfuWriterMut {
-    /// writes a chunk of data to a component and reads back to another buffer
-    fn cfu_write_read(
-        &mut self,
-        mem_offset: Option<usize>,
-        data: &[u8],
-        read: &mut [u8],
-    ) -> impl Future<Output = Result<(), CfuWriterError>>;
-    /// Fills a given buffer with data from the component
-    fn cfu_read(
-        &mut self,
-        mem_offset: Option<usize>,
-        read: &mut [u8],
-    ) -> impl Future<Output = Result<(), CfuWriterError>>;
-    /// Writes a given buffer of data to a component
-    /// Note: we don't need cfu_write as cfu_storage may replace it.
-    fn cfu_write(&mut self, mem_offset: Option<usize>, data: &[u8])
-        -> impl Future<Output = Result<(), CfuWriterError>>;
-    /// Manages erasing sectors and writing pages into flash based on the CFU offset
-    fn cfu_storage(&mut self, mem_offset: usize, data: &[u8]) -> impl Future<Output = Result<(), CfuWriterError>>;
-}
-
-/// Trait to define R/W behavior for driver that can talk to a CFU component or client
-pub trait CfuWriter {
-    /// writes a chunk of data to a component and reads back to another buffer
-    fn cfu_write_read(
-        &self,
-        mem_offset: Option<usize>,
-        data: &[u8],
-        read: &mut [u8],
-    ) -> impl Future<Output = Result<(), CfuWriterError>>;
-    /// Fills a given buffer with data from the component
-    fn cfu_read(&self, mem_offset: Option<usize>, read: &mut [u8]) -> impl Future<Output = Result<(), CfuWriterError>>;
-    /// Writes a given buffer of data to a component
-    fn cfu_write(&self, mem_offset: Option<usize>, data: &[u8]) -> impl Future<Output = Result<(), CfuWriterError>>;
-}
-
 pub type DataChunk = [u8; DEFAULT_DATA_LENGTH];
-
-#[derive(Copy, Clone)]
-pub struct CfuWriterDefault {}
-
-impl CfuWriterDefault {
-    /// Create new instance
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Default for CfuWriterDefault {
-    /// Creates default instance of CfuWriterDefault
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl CfuWriter for CfuWriterDefault {
-    /// writes a chunk of data to a component and reads back to another buffer
-    async fn cfu_write_read(&self, offset: Option<usize>, write: &[u8], read: &mut [u8]) -> Result<(), CfuWriterError> {
-        // TODO: add with_timeout to these calls
-        self.cfu_write(offset, write).await?;
-        self.cfu_read(offset, read).await?;
-        Ok(())
-    }
-    /// Fills a given buffer with 0xBE 0xEF alternating bytes
-    async fn cfu_read(&self, _offset: Option<usize>, read: &mut [u8]) -> Result<(), CfuWriterError> {
-        info!("Fake reading from component");
-        for (i, byte) in read.iter_mut().enumerate() {
-            if i % 2 == 0 {
-                *byte = 0xEF;
-            } else {
-                *byte = 0xBE;
-            }
-        }
-        Ok(())
-    }
-    async fn cfu_write(&self, _offset: Option<usize>, write: &[u8]) -> Result<(), CfuWriterError> {
-        info!("Fake writing to component: {:?}", write);
-        Ok(())
-    }
-}

--- a/src/protocol_definitions.rs
+++ b/src/protocol_definitions.rs
@@ -1,6 +1,6 @@
 use core::convert::TryFrom;
 
-use crate::CfuWriterError;
+use crate::writer::CfuWriterError;
 
 // Max is 7 components in CfuUpdateOfferResponse, 1 primary and 6 subcomponents
 pub const MAX_CMPT_COUNT: usize = 7;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,94 @@
+//! This module defines traits use to read and write data to CFU component or client.
+
+use core::future::Future;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CfuWriterError {
+    StorageError,
+    ByteConversionError,
+    Other,
+}
+
+/// Trait to define R/W behavior for driver that can talk to a CFU component or client
+pub trait CfuWriterAsync {
+    /// writes a chunk of data to a component and reads back to another buffer
+    fn cfu_write_read(
+        &mut self,
+        mem_offset: Option<usize>,
+        data: &[u8],
+        read: &mut [u8],
+    ) -> impl Future<Output = Result<(), CfuWriterError>>;
+
+    /// Fills a given buffer with data from the component
+    fn cfu_read(
+        &mut self,
+        mem_offset: Option<usize>,
+        read: &mut [u8],
+    ) -> impl Future<Output = Result<(), CfuWriterError>>;
+
+    /// Writes a given buffer of data to a component
+    fn cfu_write(&mut self, mem_offset: Option<usize>, data: &[u8])
+        -> impl Future<Output = Result<(), CfuWriterError>>;
+
+    /// Manages erasing sectors and writing pages into flash based on the CFU offset
+    fn cfu_storage(&mut self, mem_offset: usize, data: &[u8]) -> impl Future<Output = Result<(), CfuWriterError>>;
+}
+
+/// Trait to define R/W behavior for driver that can talk to a CFU component or client
+pub trait CfuWriterSync {
+    /// writes a chunk of data to a component and reads back to another buffer
+    fn cfu_write_read(&self, mem_offset: Option<usize>, data: &[u8], read: &mut [u8]) -> Result<(), CfuWriterError>;
+
+    /// Fills a given buffer with data from the component
+    fn cfu_read(&mut self, mem_offset: Option<usize>, read: &mut [u8]) -> Result<(), CfuWriterError>;
+
+    /// Writes a given buffer of data to a component
+    fn cfu_write(&mut self, mem_offset: Option<usize>, data: &[u8]) -> Result<(), CfuWriterError>;
+
+    /// Manages erasing sectors and writing pages into flash based on the CFU offset
+    fn cfu_storage(&mut self, mem_offset: usize, data: &[u8]) -> Result<(), CfuWriterError>;
+}
+
+pub struct CfuWriterNop;
+
+impl CfuWriterAsync for CfuWriterNop {
+    async fn cfu_write_read(
+        &mut self,
+        _mem_offset: Option<usize>,
+        _data: &[u8],
+        _read: &mut [u8],
+    ) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+
+    async fn cfu_read(&mut self, _mem_offset: Option<usize>, _read: &mut [u8]) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+
+    async fn cfu_write(&mut self, _mem_offset: Option<usize>, _data: &[u8]) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+
+    async fn cfu_storage(&mut self, _mem_offset: usize, _data: &[u8]) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+}
+
+impl CfuWriterSync for CfuWriterNop {
+    fn cfu_write_read(&self, _mem_offset: Option<usize>, _data: &[u8], _read: &mut [u8]) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+
+    fn cfu_read(&mut self, _mem_offset: Option<usize>, _read: &mut [u8]) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+
+    fn cfu_write(&mut self, _mem_offset: Option<usize>, _data: &[u8]) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+
+    fn cfu_storage(&mut self, _mem_offset: usize, _data: &[u8]) -> Result<(), CfuWriterError> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a sync version of `CfuWriter` and merged `CfuWriterMut` with `CfuWriter`.

- The previous `CfuWriter` is now named `CfuWriterAsync` and the synchronous version is named `CfuWriterSync`. To keep the previous behavior, use `CfuWriterAsync`.  
- Rename the Default Writer to `CfuWriterNop` to be more explicit about what it does.
- Removed default implementations that were not default behavior. The reason for the change, add clarity to the user about which function needs to be implemented to have a working writer and will "force" the use to implement these functions. In the event where someone wants a dummy implementation, the intent will be clearer now that it is moved where the implementation is.

# Issues

Fix #5  
Fix #17 